### PR TITLE
Added pillar_cache option to config dict

### DIFF
--- a/test_salt_state.py
+++ b/test_salt_state.py
@@ -128,6 +128,7 @@ OPTIONS = ConfObj(
 
 # pylint: disable=line-too-long
 CONFIG = {
+    'pillar_cache': False,
     'output_file_append': False,
     'ioflo_realtime': True,
     'master_alive_interval': 0,


### PR DESCRIPTION
Needed to work with salt version >= 2016.3.2:
```
Traceback (most recent call last):
  File "test/test_salt_state.py", line 562, in <module>
    main()
  File "test/test_salt_state.py", line 543, in main
    print_state_json(states_list[0])
  File "test/test_salt_state.py", line 485, in print_state_json
    call_result = salt_call()
  File "test/test_salt_state.py", line 324, in salt_call
    caller = LocalCaller(CONFIG)
  File "test/test_salt_state.py", line 354, in __init__
    self.minion = salt.minion.SMinion(self.config)
  File "/Users/syndicut/miniconda2/lib/python2.7/site-packages/salt/minion.py", line 595, in __init__
    self.gen_modules(initial_load=True)
  File "/Users/syndicut/miniconda2/lib/python2.7/site-packages/salt/minion.py", line 626, in gen_modules
    pillarenv=self.opts.get('pillarenv'),
  File "/Users/syndicut/miniconda2/lib/python2.7/site-packages/salt/pillar/__init__.py", line 53, in get_pillar
    if opts['pillar_cache']:
KeyError: 'pillar_cache'
```